### PR TITLE
Thread Safe implementation of PremailerContact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ buildNumber.properties
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.databene</groupId>
+            <artifactId>contiperf</artifactId>
+            <version>2.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/msiops/premailer/PremailerInterface.java
+++ b/src/main/java/com/msiops/premailer/PremailerInterface.java
@@ -4,10 +4,8 @@ import java.util.Map;
 
 public interface PremailerInterface {
 
-    public Object init( String html, Map<String, Object> options );
+    String inline_css( String html, Map<String, Object> options );
 
-    String inline_css();
-
-    String plain_text();
+    String plain_text( String html, Map<String, Object> options );
 }
 

--- a/src/main/ruby/premailer/premailer_contact.rb
+++ b/src/main/ruby/premailer/premailer_contact.rb
@@ -1,12 +1,13 @@
 require "java"
 require "premailer"
+require "jruby/synchronized"
 
 #$CLASSPATH << 'target/classes';
 java_import "com.msiops.premailer.PremailerInterface"
 
 # see https://github.com/jruby/jruby/issues/1249
 
-if ENV_JAVA['java.specification.version'] >= '1.8'  
+if ENV_JAVA['java.specification.version'] >= '1.8'
   class Java::JavaUtil::HashMap
     def merge(other)
       dup.merge!(other)
@@ -16,6 +17,7 @@ end
 
 class PremailerContact
   include PremailerInterface
+  include JRuby::Synchronized
 
   def initialize
   end
@@ -26,18 +28,18 @@ class PremailerContact
     end
 
     @defaultOption = {:adapter => :nokogiri, :input_encoding => 'UTF-8', }
-    
-    @pr = Premailer.new(html, options.merge(@defaultOption))
+
+    return Premailer.new(html, options.merge(@defaultOption))
   end
 
 
-  def inline_css
-    return @pr.to_inline_css
+  def inline_css(html, options)
+    return init(html, options).to_inline_css
   end
 
 
-  def plain_text
-    return @pr.to_plain_text
+  def plain_text(html, options)
+    return init(html, options).to_plain_text
   end
 
 end

--- a/src/test/java/com/msiops/premailer/PremailerInlineHTMLTest.java
+++ b/src/test/java/com/msiops/premailer/PremailerInlineHTMLTest.java
@@ -1,0 +1,51 @@
+package com.msiops.premailer;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.databene.contiperf.PerfTest;
+import org.databene.contiperf.junit.ContiPerfRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.msiops.premailer.Premailer;
+import com.msiops.premailer.PremailerInterface;
+
+public class PremailerInlineHTMLTest {
+
+    @Rule
+    public final ContiPerfRule i = new ContiPerfRule();
+
+    final PremailerInterface premailer = new Premailer().getPremailerInstance();
+
+    @Test
+    public void shouldInlineCss() throws Exception {
+        final String html = "<html><head><style>body{ margin: 0; }</style></head><body></body></html>";
+
+        final Map<String, Object> options = new HashMap<>();
+        options.put("with_html_string", true);
+
+        final String inline = premailer.inline_css(html, options);
+
+        assertThat(inline, is(notNullValue()));
+        assertThat(inline, is("<html><head></head><body style=\"margin: 0;\"><style type=\"text/css\">\nbody {\nmargin: 0;\n}\n</style></body></html>"));
+    }
+
+    @PerfTest(invocations = 1000, threads = 5)
+    @Test
+    public void shouldInlineCSSInThreadSafeManner() throws Exception {
+        final String html = "<html><head><style>body{ margin: 0; }</style></head><body></body></html>";
+
+        final Map<String, Object> options = new HashMap<>();
+        options.put("with_html_string", true);
+
+        final String inline = premailer.inline_css(html, options);
+
+        assertThat(inline, is(notNullValue()));
+        assertThat(inline, is("<html><head></head><body style=\"margin: 0;\"><style type=\"text/css\">\nbody {\nmargin: 0;\n}\n</style></body></html>"));
+    }
+
+}

--- a/src/test/java/com/msiops/premailer/PremailerPlainTextTest.java
+++ b/src/test/java/com/msiops/premailer/PremailerPlainTextTest.java
@@ -1,0 +1,50 @@
+package com.msiops.premailer;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.databene.contiperf.PerfTest;
+import org.databene.contiperf.junit.ContiPerfRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.msiops.premailer.Premailer;
+import com.msiops.premailer.PremailerInterface;
+
+public class PremailerPlainTextTest {
+
+    @Rule
+    public final ContiPerfRule i = new ContiPerfRule();
+
+    final PremailerInterface premailer = new Premailer().getPremailerInstance();
+
+    @Test
+    public void shouldPlainText() throws Exception {
+        final String html = "<html><head><style>body{ margin: 0; }</style></head><body>Sample Text</body></html>";
+
+        final Map<String, Object> options = new HashMap<>();
+        options.put("with_html_string", true);
+
+        final String inline = premailer.plain_text(html, options);
+
+        assertThat(inline, is(notNullValue()));
+        assertThat(inline, is("Sample Text"));
+    }
+
+    @PerfTest(invocations = 1000, threads = 5)
+    @Test
+    public void shouldPlainTextInThreadSafeManner() throws Exception {
+        final String html = "<html><head><style>body{ margin: 0; }</style></head><body>Sample Text</body></html>";
+
+        final Map<String, Object> options = new HashMap<>();
+        options.put("with_html_string", true);
+
+        final String inline = premailer.plain_text(html, options);
+
+        assertThat(inline, is(notNullValue()));
+        assertThat(inline, is("Sample Text"));
+    }
+}


### PR DESCRIPTION
- Fixes #6
- Removes the init method from PremailerInterface

- Removes state from PremailerCcontact class

- Synchronizes methods of PremailerContact class as creating new instance of Premailer does dynamic loading of
classes (jars) which isn't thread safe

- Adds unit tests